### PR TITLE
Update lovely-tag.js

### DIFF
--- a/dist/lovely-tag.js
+++ b/dist/lovely-tag.js
@@ -13,7 +13,7 @@
         value: this.text,
         checked: 'checked'
       });
-      this.$ele = $('<div>').addClass('tag').text("" + (hasHashTag ? '#' : void 0) + this.text).append(this.$checkbox).click((function(_this) {
+      this.$ele = $('<div>').addClass('tag').text("" + (hasHashTag ? '#' : '') + this.text).append(this.$checkbox).click((function(_this) {
         return function() {
           if (_this.$ele.hasClass('to-be-crossed')) {
             return _this.destroy();


### PR DESCRIPTION
 Conditional (ternary) operator returns empty string if hasHashTag == false

I spent hours figuring out why my tags had the string 'undefined' in front of their text. I tried everything and I can't believe that this was the cause